### PR TITLE
Remove WWW-Authenticate from 401 response

### DIFF
--- a/lib/lager.rb
+++ b/lib/lager.rb
@@ -40,7 +40,7 @@ class App
     end
 
     def respond_as_unauthorized
-      headers['WWW-Authenticate'] = 'Basic realm="Restricted Area"'
+      # headers['WWW-Authenticate'] = 'Basic realm="Restricted Area"'
       halt 401, "Not authorized\n"
     end
   end


### PR DESCRIPTION
Removed the authenticate from header to prevent the auth popups from appearing when a 401 is returned.
